### PR TITLE
Open news instead of image on item click

### DIFF
--- a/app/src/main/java/com/droidcba/kedditbysteps/api/ApiModels.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/api/ApiModels.kt
@@ -16,5 +16,5 @@ class RedditNewsDataResponse(
         val num_comments: Int,
         val created: Long,
         val thumbnail: String,
-        val url: String?
+        val permalink: String?
 )

--- a/app/src/main/java/com/droidcba/kedditbysteps/features/news/NewsFragment.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/features/news/NewsFragment.kt
@@ -27,7 +27,7 @@ class NewsFragment : RxBaseFragment(), NewsDelegateAdapter.onViewSelectedListene
             Snackbar.make(news_list, "No URL assigned to this news", Snackbar.LENGTH_LONG).show()
         } else {
             val intent = Intent(Intent.ACTION_VIEW)
-            intent.data = Uri.parse(url)
+            intent.data = Uri.parse("https://www.reddit.com" + url)
             startActivity(intent)
         }
     }


### PR DESCRIPTION
The current implementation opens the image of the news in the browser.
This PR allows the news to be opened instead.