### PR TITLE
Utilize retrofit rxjava(1) adapter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     // Retrofit
     compile 'com.squareup.retrofit2:retrofit:2.0.0'
     compile 'com.squareup.retrofit2:converter-moshi:2.0.0'
+    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
 
     // Dagger 2
     compile 'com.google.dagger:dagger:2.4'

--- a/app/src/main/java/com/droidcba/kedditbysteps/api/NewsAPI.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/api/NewsAPI.kt
@@ -1,6 +1,6 @@
 package com.droidcba.kedditbysteps.api
 
-import retrofit2.Call
+import rx.Observable
 
 /**
  * News API
@@ -8,5 +8,5 @@ import retrofit2.Call
  * @author juancho.
  */
 interface NewsAPI {
-    fun getNews(after: String, limit: String): Call<RedditNewsResponse>
+    fun getNews(after: String, limit: String): Observable<RedditNewsResponse>
 }

--- a/app/src/main/java/com/droidcba/kedditbysteps/api/NewsRestAPI.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/api/NewsRestAPI.kt
@@ -1,11 +1,11 @@
 package com.droidcba.kedditbysteps.api
 
-import retrofit2.Call
+import rx.Observable
 import javax.inject.Inject
 
 class NewsRestAPI @Inject constructor(private val redditApi: RedditApi) : NewsAPI {
 
-    override fun getNews(after: String, limit: String): Call<RedditNewsResponse> {
+    override fun getNews(after: String, limit: String): Observable<RedditNewsResponse> {
         return redditApi.getTop(after, limit)
     }
 }

--- a/app/src/main/java/com/droidcba/kedditbysteps/api/RedditApi.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/api/RedditApi.kt
@@ -1,11 +1,11 @@
 package com.droidcba.kedditbysteps.api
 
-import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
+import rx.Observable
 
 interface  RedditApi {
     @GET("/top.json")
     fun getTop(@Query("after") after: String,
-               @Query("limit") limit: String): Call<RedditNewsResponse>;
+               @Query("limit") limit: String): Observable<RedditNewsResponse>;
 }

--- a/app/src/main/java/com/droidcba/kedditbysteps/features/news/NewsManager.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/features/news/NewsManager.kt
@@ -1,6 +1,7 @@
 package com.droidcba.kedditbysteps.features.news
 
 import com.droidcba.kedditbysteps.api.NewsAPI
+import com.droidcba.kedditbysteps.api.RedditNewsResponse
 import com.droidcba.kedditbysteps.commons.RedditNews
 import com.droidcba.kedditbysteps.commons.RedditNewsItem
 import rx.Observable
@@ -23,28 +24,21 @@ class NewsManager @Inject constructor(private val api: NewsAPI) {
      * @param limit the number of news to request.
      */
     fun getNews(after: String, limit: String = "10"): Observable<RedditNews> {
-        return Observable.create {
-            subscriber ->
-            val callResponse = api.getNews(after, limit)
-            val response = callResponse.execute()
+        return api.getNews(after, limit)
+                .map { extractNewsFromResponse(it) }
+    }
 
-            if (response.isSuccessful) {
-                val dataResponse = response.body().data
-                val news = dataResponse.children.map {
-                    val item = it.data
-                    RedditNewsItem(item.author, item.title, item.num_comments,
-                            item.created, item.thumbnail, item.url)
-                }
-                val redditNews = RedditNews(
-                        dataResponse.after ?: "",
-                        dataResponse.before ?: "",
-                        news)
 
-                subscriber.onNext(redditNews)
-                subscriber.onCompleted()
-            } else {
-                subscriber.onError(Throwable(response.message()))
-            }
+    fun extractNewsFromResponse(b: RedditNewsResponse): RedditNews {
+        val news = b.data.children.map {
+            val item = it.data
+            RedditNewsItem(item.author, item.title, item.num_comments,
+                    item.created, item.thumbnail, item.url)
         }
+        return RedditNews(
+                b.data.after ?: "",
+                b.data.before ?: "",
+                news
+        )
     }
 }


### PR DESCRIPTION
- Rather than binding rxjava to retrofit call structure, it
  is more idiomatic to use the rxjava adapter for retrofit
  and handle errors through its normal onError for the observable

- **TESTS DO NOT PASS**. This is a POC commit for a blog tutorial repo.
  I did not take the time to change the tests and make them pass.
  The mocked out calls will need to change and the way errors are
  detected will need to follow the normal observable pattern.