### PR TITLE
Refactor news viewholder

### DIFF
--- a/app/src/main/java/com/droidcba/kedditbysteps/features/news/adapter/NewsDelegateAdapter.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/features/news/adapter/NewsDelegateAdapter.kt
@@ -30,7 +30,6 @@ class NewsDelegateAdapter(val viewActions: onViewSelectedListener) : ViewTypeDel
             parent.inflate(R.layout.news_item)) {
 
         fun bind(item: RedditNewsItem) = with(itemView) {
-            //Picasso.with(itemView.context).load(item.thumbnail).into(img_thumbnail)
             img_thumbnail.loadImg(item.thumbnail)
             description.text = item.title
             author.text = item.author

--- a/app/src/main/java/com/droidcba/kedditbysteps/features/news/adapter/NewsDelegateAdapter.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/features/news/adapter/NewsDelegateAdapter.kt
@@ -29,8 +29,14 @@ class NewsDelegateAdapter(val viewActions: onViewSelectedListener) : ViewTypeDel
     inner class NewsViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
             parent.inflate(R.layout.news_item)) {
 
-        fun bind(item: RedditNewsItem) = with(itemView) {
-            img_thumbnail.loadImg(item.thumbnail)
+        private val imgThumbnail = itemView.img_thumbnail
+        private val description = itemView.description
+        private val author = itemView.author
+        private val comments = itemView.comments
+        private val time = itemView.time
+
+        fun bind(item: RedditNewsItem) {
+            imgThumbnail.loadImg(item.thumbnail)
             description.text = item.title
             author.text = item.author
             comments.text = "${item.numComments} comments"


### PR DESCRIPTION
The way the `NewsViewHolder` is currently implemented it is calling `findViewById` whenever it needs to `bind` a `RedditNewsItem` in the `news_item` view. 

This is counterintuitive since the `RecyclerView` is supposed to implement the `ViewHolder` pattern automatically.