### PR TITLE
Simplify InfiniteScrollListener

### DIFF
--- a/app/src/main/java/com/droidcba/kedditbysteps/commons/InfiniteScrollListener.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/commons/InfiniteScrollListener.kt
@@ -10,7 +10,6 @@ class InfiniteScrollListener(
 
     private var previousTotal = 0
     private var loading = true
-    private val visibleThreshold = 2
 
     override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
         super.onScrolled(recyclerView, dx, dy)
@@ -27,7 +26,7 @@ class InfiniteScrollListener(
                 }
             }
             if (!loading && (totalItemCount - visibleItemCount)
-                    <= (firstVisibleItem + visibleThreshold)) {
+                    <= (firstVisibleItem + VISIBLE_THRESHOLD)) {
                 // End has been reached
                 Log.i("InfiniteScrollListener", "End reached")
                 func()
@@ -36,4 +35,7 @@ class InfiniteScrollListener(
         }
     }
 
+    companion object {
+        const val VISIBLE_THRESHOLD = 2
+    }
 }

--- a/app/src/main/java/com/droidcba/kedditbysteps/commons/InfiniteScrollListener.kt
+++ b/app/src/main/java/com/droidcba/kedditbysteps/commons/InfiniteScrollListener.kt
@@ -10,18 +10,15 @@ class InfiniteScrollListener(
 
     private var previousTotal = 0
     private var loading = true
-    private var visibleThreshold = 2
-    private var firstVisibleItem = 0
-    private var visibleItemCount = 0
-    private var totalItemCount = 0
+    private val visibleThreshold = 2
 
     override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
         super.onScrolled(recyclerView, dx, dy)
 
         if (dy > 0) {
-            visibleItemCount = recyclerView.childCount
-            totalItemCount = layoutManager.itemCount
-            firstVisibleItem = layoutManager.findFirstVisibleItemPosition()
+            val visibleItemCount = recyclerView.childCount
+            val totalItemCount = layoutManager.itemCount
+            val firstVisibleItem = layoutManager.findFirstVisibleItemPosition()
 
             if (loading) {
                 if (totalItemCount > previousTotal) {


### PR DESCRIPTION
It appears that you don't need to store ```visibleItemCount```, ```totalItemCount``` and ```firstVisibleItem``` as member variables of the listener, since they are recalculated on every invocation of ```onScrolled``` and aren't used anywhere else.
Also, I guess it is a good coding practice to store ```VISIBLE_THRESHOLD```  as a ```const val``` in the listener's ```companion object```